### PR TITLE
Full HTML parsing instead of fragment and attribute fix

### DIFF
--- a/lib/thymeleaf/dialects/default/processors/default.rb
+++ b/lib/thymeleaf/dialects/default/processors/default.rb
@@ -2,7 +2,7 @@ class DefaultProcessor
   include Thymeleaf::Processor
 
   def call(key:nil, node:nil, attribute:nil, context:nil)
-    node[key] = [node[key], EvalExpression.parse(context, attribute.value)].compact.join(' ')
+    node[key] = EvalExpression.parse(context, attribute.value)
     attribute.unlink
   end
 end

--- a/lib/thymeleaf/parser.rb
+++ b/lib/thymeleaf/parser.rb
@@ -5,7 +5,11 @@ module Thymeleaf
 
   class Parser < Struct.new(:template_markup)
     def call
-      Nokogiri::HTML::fragment(template_markup, Thymeleaf.configuration.parser.encoding)
+      if(template_markup.start_with?('<!DOCTYPE', '<html'))
+        Nokogiri::HTML(template_markup, Thymeleaf.configuration.parser.encoding)
+      else
+        Nokogiri::HTML::fragment(template_markup, Thymeleaf.configuration.parser.encoding)
+      end
     end
   end
 

--- a/lib/thymeleaf/parser.rb
+++ b/lib/thymeleaf/parser.rb
@@ -5,7 +5,7 @@ module Thymeleaf
 
   class Parser < Struct.new(:template_markup)
     def call
-      if(template_markup.start_with?('<!DOCTYPE', '<html'))
+      if /^\s*(?:\s*<!--[^>]*-->)*\s*<(?:html|!doctype)/i.match(template_markup)
         Nokogiri::HTML(template_markup, Thymeleaf.configuration.parser.encoding)
       else
         Nokogiri::HTML::fragment(template_markup, Thymeleaf.configuration.parser.encoding)

--- a/lib/thymeleaf/template_engine.rb
+++ b/lib/thymeleaf/template_engine.rb
@@ -18,8 +18,10 @@ module Thymeleaf
 
     def process_attributes(context_holder, node)
       attr_context = context_holder
-      node.attributes.each do |attribute_key, attribute|
-        attr_context = process_attribute(attr_context, node, attribute_key, attribute)
+      if(node.respond_to?(:attributes))
+        node.attributes.each do |attribute_key, attribute|
+          attr_context = process_attribute(attr_context, node, attribute_key, attribute)
+        end
       end
       attr_context
     end

--- a/test/templates/each.th.test
+++ b/test/templates/each.th.test
@@ -50,7 +50,7 @@
         
         <td>First</td>
         
-        <td class="label fair CLASS_NAME1 expr class_name2">p1</td>
+        <td class="fair CLASS_NAME1 expr class_name2">p1</td>
         <td class="value">0.5</td>
         <td><span>cat1</span><span>cat2</span></td>
     </tr>
@@ -61,7 +61,7 @@
         <td>Even</td>
         
         <td>Last</td>
-        <td class="label fair CLASS_NAME1 expr class_name2">p2</td>
+        <td class="fair CLASS_NAME1 expr class_name2">p2</td>
         <td class="value">0.6</td>
         <td></td>
     </tr>

--- a/test/templates/template.th.test
+++ b/test/templates/template.th.test
@@ -57,12 +57,12 @@
 
 <table>
     <tr>
-        <td class="label fair CLASS_NAME1 expr class_name2">p1</td>
+        <td class="fair CLASS_NAME1 expr class_name2">p1</td>
         <td class="value">0.5</td>
         <td><span>cat1</span><span>cat2</span></td>
     </tr>
 <tr>
-        <td class="label fair CLASS_NAME1 expr class_name2">p2</td>
+        <td class="fair CLASS_NAME1 expr class_name2">p2</td>
         <td class="value">0.6</td>
         <td></td>
     </tr>
@@ -87,7 +87,7 @@
 <table>
 <% products.each do |product| %>
     <tr>
-      <td class="label fair <%= a.upcase %> expr <%= b %>"><%= product.name %></td>
+      <td class="fair <%= a.upcase %> expr <%= b %>"><%= product.name %></td>
       <td class="<%= 'value' %>"><%= product.price %></td>
       <td><% product.categories.each do |category| %><span><%= category %></span> <% end %></td>
     </tr>

--- a/test/thymeleaf/dialects/default/processors/default_test.rb
+++ b/test/thymeleaf/dialects/default/processors/default_test.rb
@@ -1,0 +1,17 @@
+require 'thymeleaf/dialects/default/processors/default'
+require 'thymeleaf/context/context_struct'
+require 'thymeleaf/context/context_holder'
+
+describe DefaultProcessor do
+
+  def context
+    ContextHolder.new(ContextStruct.new())
+  end
+
+  it 'renders data attribute without concatenation' do
+    node = {'placeholder'=>'initial'}
+    attr = Nokogiri::HTML::DocumentFragment.parse('<input data-th-placeholder="new"/>').children[0].attributes["data-th-placeholder"]
+    DefaultProcessor.new.call(key: 'placeholder', node: node, attribute: attr, context: context)
+    assert_equal 'new', node['placeholder']
+  end
+end


### PR DESCRIPTION
If the template was a full-page template, including DTD html, head and body, fragment parsing would strip out the DTD, html and head tags, mashing everything up under body. That's not cool.
This change uses HTML parsing instead of HTML::fragment to avoid that, if the template starts with the DTD or html.
Checked the tests, everything should be good.